### PR TITLE
ARP Table improvement - entries are no longer added on every IP packe…

### DIFF
--- a/utility/uip.h
+++ b/utility/uip.h
@@ -1562,11 +1562,11 @@ struct uip_eth_addr {
  Check if a MAC address is valid (non-zero)
  */
 #define uip_eth_addr_valid(addr) ( \
-		addr[0] != 0x00 && \
-		addr[1] != 0x00 && \
-		addr[2] != 0x00 && \
-		addr[3] != 0x00 && \
-		addr[4] != 0x00 && \
+		addr[0] != 0x00 || \
+		addr[1] != 0x00 || \
+		addr[2] != 0x00 || \
+		addr[3] != 0x00 || \
+		addr[4] != 0x00 || \
 		addr[5] != 0x00)
 
 /**

--- a/utility/uip.h
+++ b/utility/uip.h
@@ -1559,6 +1559,17 @@ struct uip_eth_addr {
 };
 
 /**
+ Check if a MAC address is valid (non-zero)
+ */
+#define uip_eth_addr_valid(addr) ( \
+		addr[0] != 0x00 && \
+		addr[1] != 0x00 && \
+		addr[2] != 0x00 && \
+		addr[3] != 0x00 && \
+		addr[4] != 0x00 && \
+		addr[5] != 0x00)
+
+/**
  * Calculate the Internet checksum over a buffer.
  *
  * The Internet checksum is the one's complement of the one's

--- a/utility/uip_arp.c
+++ b/utility/uip_arp.c
@@ -58,7 +58,6 @@
  *
  */
 
-
 #include "uip_arp.h"
 
 #include <string.h>
@@ -246,8 +245,22 @@ uip_arp_ipin(void)
      (uip_hostaddr[1] & uip_netmask[1])) {
     return;
   }
+  /* Insert the entry only if it was ment for us (not broadcast) or already appears in the table */
+#if UIP_ADD_ALL_BROADCAST_TO_ARP
   uip_arp_update(IPBUF->srcipaddr, &(IPBUF->ethhdr.src));
-  
+#else 
+  if(uip_ipaddr_cmp(IPBUF->destipaddr, uip_hostaddr)) {
+    uip_arp_update(IPBUF->srcipaddr, &(IPBUF->ethhdr.src));
+  } else {
+    for(i = 0; i < UIP_ARPTAB_SIZE; ++i) {
+      struct arp_entry *tabptr = &arp_table[i];
+      if(uip_ipaddr_cmp(IPBUF->srcipaddr, tabptr->ipaddr)) {
+        uip_arp_update(IPBUF->srcipaddr, &(IPBUF->ethhdr.src));
+	break;
+      }
+    }
+  }
+#endif  
   return;
 }
 //#endif /* 0 */
@@ -379,7 +392,11 @@ uip_arp_out(void)
       
     for(i = 0; i < UIP_ARPTAB_SIZE; ++i) {
       tabptr = &arp_table[i];
+#if UIP_ADD_ALL_BROADCAST_TO_ARP
       if(uip_ipaddr_cmp(ipaddr, tabptr->ipaddr)) {
+#else 
+      if(uip_ipaddr_cmp(ipaddr, tabptr->ipaddr) && uip_eth_addr_valid(tabptr->ethaddr.addr)) {
+#endif
 	break;
       }
     }
@@ -405,6 +422,13 @@ uip_arp_out(void)
       uip_appdata = &uip_buf[UIP_TCPIP_HLEN + UIP_LLH_LEN];
     
       uip_len = sizeof(struct arp_hdr);
+#if UIP_ADD_ALL_BROADCAST_TO_ARP
+#else
+      /* Insert an invalid entry in the table */
+      struct uip_eth_addr zero_address;
+      memset(zero_address.addr, 0, 6);
+      uip_arp_update(ipaddr, &zero_address);
+#endif
       return;
     }
 
@@ -417,6 +441,16 @@ uip_arp_out(void)
 
   uip_len += sizeof(struct uip_eth_hdr);
 }
+/*-----------------------------------------------------------------------------------*/
+
+/**
+ * Debug method used to get a pointer to the arp table. Useful
+ * to print and examine the data
+ */
+//void * uip_debug_get_arp_table_ref(void) {
+//  return (void*)arp_table;
+//}
+
 /*-----------------------------------------------------------------------------------*/
 
 /** @} */

--- a/utility/uip_arp.h
+++ b/utility/uip_arp.h
@@ -45,6 +45,13 @@
  *
  * This file is part of the uIP TCP/IP stack.
  *
+ * Modification by Dimitar Kunchev: ARP table is not filled on every 
+ * received packet because it overflows when there is a lot of broadcast. 
+ * Instead when we send an ARP request we add zero MAC address (which 
+ * is supposedly invalid) and update it when we have a reply. We also
+ * save the entry when we receive an IP packet sent to us.
+ * This behaviour can be switched via UIP_CONF_ADD_ALL_BROADCAST_TO_ARP
+ * 
  * $Id: uip_arp.h,v 1.5 2006/06/11 21:46:39 adam Exp $
  *
  */
@@ -53,7 +60,6 @@
 #define __UIP_ARP_H__
 
 #include "uip.h"
-
 
 extern struct uip_eth_addr uip_ethaddr;
 
@@ -137,6 +143,12 @@ void uip_arp_timer(void);
                               uip_ethaddr.addr[3] = eaddr.addr[3];\
                               uip_ethaddr.addr[4] = eaddr.addr[4];\
                               uip_ethaddr.addr[5] = eaddr.addr[5];} while(0)
+
+/**
+ * Debug method - get a pointer to the arp table to arduino code 
+ * to be able to examine and print it
+ */
+// void * uip_debug_get_arp_table_ref(void);
 
 /** @} */
 /** @} */

--- a/utility/uipopt.h
+++ b/utility/uipopt.h
@@ -461,6 +461,21 @@
 #endif /* UIP_CONF_BROADCAST */
 
 /**
+ * Switches how entries are added to the ARP table. The original UIP 
+ * implementation just adds all received packets. By default this is 
+ * turned off and entries are added only when we receive an ARP reply 
+ * or when we send out a packet.
+ * 
+ * \hideinitializer
+ *
+ */
+#ifndef UIP_CONF_ADD_ALL_BROADCAST_TO_ARP
+#define UIP_ADD_ALL_BROADCAST_TO_ARP 0
+#else
+#define UIP_ADD_ALL_BROADCAST_TO_ARP UIP_CONF_ADD_ALL_BROADCAST_TO_ARP
+#endif 
+
+/**
  * Print out a uIP log message.
  *
  * This function must be implemented by the module that uses uIP, and


### PR DESCRIPTION
ARP Table improvement - entries are no longer blindly added on every IP packet but only on ARP replies or when needed.

This change is necessary when there are a lot of hosts sending broadcast packets in the network segment. The previous implementation would start adding the entries and eventually overflowing the ARP table, which resulted in loosing addresses for the hosts of interest (which we are trying to talk to).

For example with 8 (default) entries table if we have a dozen hosts sending UDP broadcasts we can quickly loose the address of our gateway and have to resend ARP requests. In fact you can get to the point where even when you get a reply it is quickly purged and you cannot establish any sockets.

I have done limited testing on the change but looks simple and stable enough.