### PR TITLE
public UIPEthernet::init(uint8_t pin) method, fixed warnings

### DIFF
--- a/Dns.cpp
+++ b/Dns.cpp
@@ -24,6 +24,9 @@
 #include "utility/logging.h"
 #include "utility/uip.h"
 
+#if defined(__GNUC__)
+  #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif
 
 #define SOCKET_NONE	255
 // Various flags and header field values for a DNS message
@@ -433,4 +436,3 @@ int16_t DNSClient::ProcessResponse(uint16_t aTimeout, IPAddress& aAddress)
     return -10;//INVALID_RESPONSE;
 }
 #endif
-

--- a/UIPClient.cpp
+++ b/UIPClient.cpp
@@ -238,7 +238,7 @@ newpacket:
       LogObject.uart_send_str(F("-"));
       LogObject.uart_send_dec(remain);
       LogObject.uart_send_str(F("]: '"));
-      for (uint16_t i=size-remain; i<=remain; i++)
+      for (int16_t i=size-remain; i<=remain; i++)
         {
         LogObject.uart_send_hex(buf[i]);
         LogObject.uart_send_str(F(" "));

--- a/UIPEthernet.cpp
+++ b/UIPEthernet.cpp
@@ -60,6 +60,11 @@ UIPEthernetClass::UIPEthernetClass()
 {
 }
 
+void UIPEthernetClass::init(const uint8_t pin)
+{
+  ENC28J60ControlCS = pin;
+}
+
 #if UIP_UDP
 int
 UIPEthernetClass::begin(const uint8_t* mac)
@@ -71,7 +76,7 @@ UIPEthernetClass::begin(const uint8_t* mac)
   // I leave it there commented for history. It is bring all GCC "new" memory allocation code, making the *.bin almost 40K bigger. I've move it globally.
   _dhcp = &s_dhcp;
   // Initialise the basic info
-  init(mac);
+  netInit(mac);
 
   // Now try to get our config info from a DHCP server
   int ret = _dhcp->beginWithDHCP((uint8_t*)mac);
@@ -123,7 +128,7 @@ UIPEthernetClass::begin(const uint8_t* mac, IPAddress ip, IPAddress dns, IPAddre
   #if ACTLOGLEVEL>=LOG_DEBUG_V3
     LogObject.uart_send_strln(F("UIPEthernetClass::begin(const uint8_t* mac, IPAddress ip, IPAddress dns, IPAddress gateway, IPAddress subnet) DEBUG_V3:Function started"));
   #endif
-  init(mac);
+  netInit(mac);
   configure(ip,dns,gateway,subnet);
 }
 
@@ -401,9 +406,9 @@ sendandfree:
   return true;
 }
 
-void UIPEthernetClass::init(const uint8_t* mac) {
+void UIPEthernetClass::netInit(const uint8_t* mac) {
   #if ACTLOGLEVEL>=LOG_DEBUG_V3
-    LogObject.uart_send_strln(F("UIPEthernetClass::init(const uint8_t* mac) DEBUG_V3:Function started"));
+    LogObject.uart_send_strln(F("UIPEthernetClass::netInit(const uint8_t* mac) DEBUG_V3:Function started"));
   #endif
   periodic_timer = millis() + UIP_PERIODIC_TIMER;
 

--- a/UIPEthernet.cpp
+++ b/UIPEthernet.cpp
@@ -38,6 +38,10 @@ extern "C"
 #include "utility/uip_timer.h"
 }
 
+#if defined(__GNUC__)
+  #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif
+
 #define ETH_HDR ((struct uip_eth_hdr *)&uip_buf[0])
 
 memhandle UIPEthernetClass::in_packet(NOBLOCK);

--- a/UIPEthernet.h
+++ b/UIPEthernet.h
@@ -72,6 +72,8 @@ class UIPEthernetClass
 public:
   UIPEthernetClass();
 
+  void init(const uint8_t pin);
+
   int begin(const uint8_t* mac);
   void begin(const uint8_t* mac, IPAddress ip);
   void begin(const uint8_t* mac, IPAddress ip, IPAddress dns);
@@ -100,7 +102,7 @@ private:
   #endif
   static unsigned long periodic_timer;
 
-  static void init(const uint8_t* mac);
+  static void netInit(const uint8_t* mac);
   static void configure(IPAddress ip, IPAddress dns, IPAddress gateway, IPAddress subnet);
 
   static void tick();

--- a/UIPEthernet.h
+++ b/UIPEthernet.h
@@ -20,6 +20,8 @@
 #ifndef UIPETHERNET_H
 #define UIPETHERNET_H
 
+//#define VERBOSE
+
 #include "ethernet_comp.h"
 #if defined(__MBED__)
   #include <mbed.h>

--- a/UIPUdp.cpp
+++ b/UIPUdp.cpp
@@ -28,6 +28,10 @@ extern "C" {
 #include "utility/uip_arp.h"
 }
 
+#if defined(__GNUC__)
+  #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif
+
 #if UIP_UDP
 #define UIP_ARPHDRSIZE 42
 #define UDPBUF ((struct uip_udpip_hdr *)&uip_buf[UIP_LLH_LEN])

--- a/utility/Enc28J60Network.cpp
+++ b/utility/Enc28J60Network.cpp
@@ -33,6 +33,8 @@
 #endif
 #include "logging.h"
 
+uint8_t ENC28J60ControlCS = ENC28J60_CONTROL_CS;
+
 #if ENC28J60_USE_SPILIB
    #if defined(ARDUINO)
      #if defined(STM32F2)
@@ -42,7 +44,7 @@
        extern SPIClass SPI;
      //#elif defined(ARDUINO_ARCH_AMEBA)
        //SPIClass SPI((void *)(&spi_obj), 11, 12, 13, 10);
-       //SPI _spi(SPI_MOSI,SPI_MISO,SPI_SCK,ENC28J60_CONTROL_CS);
+       //SPI _spi(SPI_MOSI,SPI_MISO,SPI_SCK,ENC28J60ControlCS);
      #else
        #include "HardwareSPI.h"
        extern HardwareSPI SPI(1);
@@ -50,7 +52,7 @@
    #endif
    #if defined(__MBED__)
      SPI _spi(SPI_MOSI,SPI_MISO,SPI_SCK);
-     DigitalOut _cs(ENC28J60_CONTROL_CS);
+     DigitalOut _cs(ENC28J60ControlCS);
      Serial LogObject(SERIAL_TX,SERIAL_RX);
    #endif
 #endif
@@ -72,9 +74,9 @@ extern "C" {
 
 #if defined(ARDUINO)
 	// set CS to 0 = active
-	#define CSACTIVE digitalWrite(ENC28J60_CONTROL_CS, LOW)
+	#define CSACTIVE digitalWrite(ENC28J60ControlCS, LOW)
 	// set CS to 1 = passive
-	#define CSPASSIVE digitalWrite(ENC28J60_CONTROL_CS, HIGH)
+	#define CSPASSIVE digitalWrite(ENC28J60ControlCS, HIGH)
 #endif
 #if defined(__MBED__)
    // set CS to 0 = active
@@ -86,10 +88,6 @@ extern "C" {
 //
 #if defined(ARDUINO_ARCH_AVR)
 #define waitspi() while(!(SPSR&(1<<SPIF)))
-#elif defined(ARDUINO_ARCH_SAM) || defined(ARDUINO_ARCH_SAMD)
-#if ENC28J60_CONTROL_CS==BOARD_SPI_SS0 or ENC28J60_CONTROL_CS==BOARD_SPI_SS1 or ENC28J60_CONTROL_CS==BOARD_SPI_SS2 or ENC28J60_CONTROL_CS==BOARD_SPI_SS3
-#define ENC28J60_USE_SPILIB_EXT 1
-#endif
 #endif
 
 uint16_t Enc28J60Network::nextPacketPtr;
@@ -114,7 +112,7 @@ void Enc28J60Network::init(uint8_t* macaddr)
   // initialize I/O
   // ss as output:
   #if defined(ARDUINO)
-  	  pinMode(ENC28J60_CONTROL_CS, OUTPUT);
+  	  pinMode(ENC28J60ControlCS, OUTPUT);
   #endif
   #if defined(__MBED__)
   	 millis_start(); 
@@ -124,7 +122,7 @@ void Enc28J60Network::init(uint8_t* macaddr)
 
   #if ACTLOGLEVEL>=LOG_DEBUG
     LogObject.uart_send_str(F("ENC28J60::init DEBUG:csPin = "));
-    LogObject.uart_send_decln(ENC28J60_CONTROL_CS);
+    LogObject.uart_send_decln(ENC28J60ControlCS);
     LogObject.uart_send_str(F("ENC28J60::init DEBUG:miso = "));
     LogObject.uart_send_decln(SPI_MISO);
     LogObject.uart_send_str(F("ENC28J60::init DEBUG:mosi = "));
@@ -181,7 +179,7 @@ void Enc28J60Network::init(uint8_t* macaddr)
   pinMode(SPI_MOSI, OUTPUT);
   pinMode(SPI_SCK, OUTPUT);
   pinMode(SPI_MISO, INPUT);
-  //Hardware SS must be configured as OUTPUT to enable SPI-master (regardless of which pin is configured as ENC28J60_CONTROL_CS)
+  //Hardware SS must be configured as OUTPUT to enable SPI-master (regardless of which pin is configured as ENC28J60ControlCS)
   pinMode(SS, OUTPUT);
   digitalWrite(SS,HIGH);
 

--- a/utility/Enc28J60Network.h
+++ b/utility/Enc28J60Network.h
@@ -78,7 +78,7 @@
       // ESP8266 (ESP8266) SS defined to pin 15
       #if defined(ARDUINO_AVR_LEONARDO)
         #define ENC28J60_CONTROL_CS     PIN_A10
-        #warning "Use LEONARDO borad PIN_A10 for ENC28J60_CONTROL_CS. You can configure in 'utility/Enc28J60Network.h'."
+        #warning "Using LEONARDO borad PIN_A10 for ENC28J60_CONTROL_CS. Use UIPEthernet::init(uint8_t) to change it."
       #else
         #define ENC28J60_CONTROL_CS     SS
       #endif
@@ -110,13 +110,13 @@
    #elif defined(__MK20DX128__) || defined(__MKL26Z64__) || defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__)
       #define ENC28J60_CONTROL_CS     PIN_SPI_SS
    #endif
-   #if defined(ENC28J60_CONTROL_CS) && !defined(ARDUINO_AVR_LEONARDO)
-      #warning "Not defined ENC28J60_CONTROL_CS. Use borad default SS pin setting. You can configure in 'utility/Enc28J60Network.h'."
-   #endif
 #endif
 #if !defined(ENC28J60_CONTROL_CS)
-   #error "Not defined ENC28J60_CONTROL_CS!"
+   #warning "Default ENC28J60_CONTROL_CS could not be defined! Use UIPEthernet::init(uint8_t) to set it."
+   #define ENC28J60_CONTROL_CS 0
 #endif
+
+extern uint8_t ENC28J60ControlCS;
 
 #if !defined(SPI_MOSI)
    #if defined(__AVR__) || defined(ESP8266) || defined(__RFduino__)

--- a/utility/Enc28J60Network.h
+++ b/utility/Enc28J60Network.h
@@ -78,7 +78,9 @@
       // ESP8266 (ESP8266) SS defined to pin 15
       #if defined(ARDUINO_AVR_LEONARDO)
         #define ENC28J60_CONTROL_CS     PIN_A10
-        #warning "Using LEONARDO borad PIN_A10 for ENC28J60_CONTROL_CS. Use UIPEthernet::init(uint8_t) to change it."
+        #if defined(VERBOSE)
+          #warning "Using LEONARDO borad PIN_A10 for ENC28J60_CONTROL_CS. Use UIPEthernet::init(uint8_t) to change it."
+        #endif
       #else
         #define ENC28J60_CONTROL_CS     SS
       #endif

--- a/utility/logging.h
+++ b/utility/logging.h
@@ -21,11 +21,14 @@
 #define	LOG_DEBUG_V2		9	/* debug-verbose-level (vv) messages */
 #define	LOG_DEBUG_V3		10	/* debug-verbose-level (vvv) messages */
 
-#warning "You can configure LogObject and ACTLOGLEVEL in 'utility/logging.h'. More verbosity more memory usage."
-#define ACTLOGLEVEL     LOG_NONE
+#if defined(VERBOSE)
+  #warning "You can configure LogObject and ACTLOGLEVEL in 'utility/logging.h'. More verbosity more memory usage."
+#endif
+#define ACTLOGLEVEL LOG_NONE
 //#define ACTLOGLEVEL LOG_WARNING
 //#define ACTLOGLEVEL LOG_INFO
 //#define ACTLOGLEVEL LOG_DEBUG_V2
+//#define ACTLOGLEVEL LOG_DEBUG_V3
 
 #if ACTLOGLEVEL>LOG_NONE 
    #if defined(ARDUINO)

--- a/utility/uip.c
+++ b/utility/uip.c
@@ -89,6 +89,10 @@
 
 #include <string.h>
 
+#if defined(__GNUC__)
+  #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif
+
 /*---------------------------------------------------------------------------*/
 /* Variable definitions. */
 

--- a/utility/uip.c
+++ b/utility/uip.c
@@ -858,7 +858,7 @@ uip_process(u8_t flag)
      the packet has been padded and we set uip_len to the correct
      value.. */
 
-  if((BUF->len[0] << 8) + BUF->len[1] <= uip_len) {
+  if((u16_t)(BUF->len[0] << 8) + BUF->len[1] <= uip_len) {
     uip_len = (BUF->len[0] << 8) + BUF->len[1];
 #if UIP_CONF_IPV6
     uip_len += 40; /* The length reported in the IPv6 header is the

--- a/utility/uip_arp.c
+++ b/utility/uip_arp.c
@@ -63,6 +63,10 @@
 
 #include <string.h>
 
+#if defined(__GNUC__)
+  #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif
+
 struct arp_hdr {
   struct uip_eth_hdr ethhdr;
   u16_t hwtype;

--- a/utility/uip_debug.cpp
+++ b/utility/uip_debug.cpp
@@ -12,6 +12,10 @@ extern "C" {
   #include "utility/uip.h"
 }
 
+#if defined(__GNUC__)
+  #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif
+
 struct uip_conn con[UIP_CONNS];
 
 void

--- a/utility/uip_debug.cpp
+++ b/utility/uip_debug.cpp
@@ -211,6 +211,8 @@ UIPDebug::uip_debug_printbytes(const uint8_t *data, uint8_t len)
       LogObject.uart_send_dec(data[i]);
       if (i<len-1)
         LogObject.uart_send_str(F(","));
+    #else
+      (void)data; // unused
     #endif
     }
 }

--- a/utility/uipopt.h
+++ b/utility/uipopt.h
@@ -91,10 +91,14 @@
 #include "uip-conf.h"
 
 #if defined(FORCE_UIP_CONF_BYTE_ORDER)
-  #warning "You forced 'FORCE_UIP_CONF_BYTE_ORDER' in 'utility/uip-conf.h'."
+  #if defined(VERBOSE)
+    #warning "You forced 'FORCE_UIP_CONF_BYTE_ORDER' in 'utility/uip-conf.h'."
+  #endif
   #define UIP_CONF_BYTE_ORDER      FORCE_UIP_CONF_BYTE_ORDER
 #elif defined(__BYTE_ORDER__)
-  #warning "Endianness configured automaticaly."
+  #if defined(VERBOSE)
+    #warning "Endianness configured automaticaly."
+  #endif
   #define UIP_CONF_BYTE_ORDER      __BYTE_ORDER__
 #else
   #error "You must set FORCE_UIP_CONF_BYTE_ORDER in 'utility/uip-conf.h'."


### PR DESCRIPTION
* **Add public UIPEthernet::init(uint8_t pin) method for easy change of used CS pin**
  This follows the API of the original Ethernet/Ethernet2 libraries.

* **Ignore -Wstrict-aliasing, added VERBOSE macro to silent unneeded #warnings**
  Do not flood user with warnings, one may miss the important ones.

* **Fixed 3 actual warnings in code**
  Nothing big, does not affect the execution.
