### PR TITLE
Fix UIPClient::read() using read() method from stream, which avoids infinite loop.

### DIFF
--- a/UIPClient.cpp
+++ b/UIPClient.cpp
@@ -351,7 +351,7 @@ UIPClient::read()
     LogObject.uart_send_strln(F("UIPClient::read() DEBUG_V3:Function started"));
   #endif
   uint8_t c;
-  if (read(&c,1) < 0)
+  if (read(&c,1) <= 0)
     return -1;
   return c;
 }


### PR DESCRIPTION
The stream read method will return -1 if there is no data available to read. 0 is a valid read byte, therefore continue till the return value is negative.

#38