### PR TITLE
DNS_DISABLE_HOSTBYNAME_RESOLUTION customization

### DIFF
--- a/Dns.cpp
+++ b/Dns.cpp
@@ -128,15 +128,17 @@ int DNSClient::inet_aton(const char* aIPAddrString, IPAddress& aResult)
 }
 
 int DNSClient::getHostByName(const char* aHostname, IPAddress& aResult)
-{
+{    
     int ret =0;
 
-    // See if it's a numeric IP address
+// See if it's a numeric IP address
     if (inet_aton(aHostname, aResult))
     {
         // It is, our work here is done
         return 1;
     }
+
+#ifndef DNS_DISABLE_HOSTBYNAME_RESOLUTION
 
     // Check we've got a valid DNS server to use
     if (iDNSServer == INADDR_NONE)
@@ -180,6 +182,8 @@ int DNSClient::getHostByName(const char* aHostname, IPAddress& aResult)
         // We're done with the socket now
         iUdp.stop();
     }
+
+#endif
 
     return ret;
 }

--- a/utility/uipopt.h
+++ b/utility/uipopt.h
@@ -60,6 +60,9 @@
 #ifndef __UIPOPT_H__
 #define __UIPOPT_H__
 
+// uncomment follow to disable hostbyname resolution (save up to 1198 flash bytes)
+//#define DNS_DISABLE_HOSTBYNAME_RESOLUTION
+
 #ifndef UIP_LITTLE_ENDIAN
   #if defined(LITTLE_ENDIAN)
     #define UIP_LITTLE_ENDIAN LITTLE_ENDIAN


### PR DESCRIPTION
I was working on a project with atmega328, sdcard and onewire ds18b20 thermometer but for a few bytes I cannot flash it, so I inspected elf to check against functions/objects that eat space and I noticed follow ( [details here](https://github.com/devel0/knowledge/blob/7103d6914d4fc93c953e314ca071262ae7586bb1/electronics/arduino-examine-elf.md) )

```
   222: 00000154  3550 FUNC    GLOBAL HIDDEN     2 uip_process
   353: 0000689a  1904 FUNC    GLOBAL DEFAULT    2 main
   220: 0000375c  1556 FUNC    GLOBAL HIDDEN     2 loop
   273: 000055ba  1320 FUNC    GLOBAL HIDDEN     2 _ZN9DNSClient13getHostByN
   363: 00001a3a  1064 FUNC    GLOBAL HIDDEN     2 _ZN16UIPEthernetClass4tic
   462: 00007b42   962 FUNC    GLOBAL DEFAULT    2 vfprintf
   231: 00003fb6   912 FUNC    GLOBAL HIDDEN     2 _ZN7FatFile4openEPS_PKch.
```
where DNSClient::getHostByName eat up to 1329 bytes but I realized that in my simple project I really don't need to convert name to ip so I applied this pull request and I finally got it working even with my enc28j60 instead of using w5500 as a countermeasure.

I know that arduino environment make it difficult to declare compiler directive that flow through all libraries sources that gets compiled so I added a macro conditional exclusion at DNSClient::getHostByName and a [commented define](https://github.com/SearchAThing-forks/UIPEthernet/blob/3dfd38b494cb7860c4d4e57d1b6cfef016928179/utility/uipopt.h#L64) to uncomment if needed in `utility/uipopt.h`. I don't know if this is satisfactory or if there are better approaches but I'll glad to know.