### PR TITLE
Fix local Broadcast Problems udp

### DIFF
--- a/utility/uip.c
+++ b/utility/uip.c
@@ -911,7 +911,7 @@ uip_process(u8_t flag)
     DEBUG_PRINTF("UDP IP checksum 0x%04x\n", uip_ipchksum());
      if(BUF->proto == UIP_PROTO_UDP && (
         uip_ipaddr_cmp(BUF->destipaddr, all_ones_addr) // Limited broadcast
-        || ((BUF->destipaddr[0]==(uip_hostaddr[0] | (~uip_netmask[0]))) && (BUF->destipaddr[1]==(uip_hostaddr[1] | (~uip_netmask[1])))) // Direct broadcast
+        || ((BUF->destipaddr[0]==(uip_hostaddr[0] | (0xFFFF&(~uip_netmask[0])))) && (BUF->destipaddr[1]==(uip_hostaddr[1] | (0XFFFF&(~uip_netmask[1]))))) // Direct broadcast
         )
        /*&&
 	 uip_ipchksum() == 0xffff*/) {

--- a/utility/uip_arp.c
+++ b/utility/uip_arp.c
@@ -376,8 +376,10 @@ uip_arp_out(void)
      packet with an ARP request for the IP address. */
 
   /* First check if destination is a local broadcast. */
-  if(uip_ipaddr_cmp(IPBUF->destipaddr, broadcast_ipaddr)) {
-    memcpy(IPBUF->ethhdr.dest.addr, broadcast_ethaddr.addr, 6);
+  if(uip_ipaddr_cmp(IPBUF->destipaddr, broadcast_ipaddr)
+        || ((IPBUF->destipaddr[0]==(uip_hostaddr[0] | (0xFFFF&(~uip_netmask[0])))) && (IPBUF->destipaddr[1]==(uip_hostaddr[1] | (0XFFFF&(~uip_netmask[1]))))) //Local Broatcast  
+    ) {
+    memcpy(IPBUF->ethhdr.dest.addr, broadcast_ethaddr.addr, 6); 
   } else {
     /* Check if the destination address is on the local network. */
     if(!uip_ipaddr_maskcmp(IPBUF->destipaddr, uip_hostaddr, uip_netmask)) {


### PR DESCRIPTION
Local broadcasts are not working!
For example if ip is 192.168.0.1 and submask 255.255.255.0
If you want to send a braodcast packet with ip 192.168.0.255 will not be send with mac adress 0xFFFF...
And the other way around is also not working. 

This pull request should fix that.