### PR TITLE
EthernetServer.accept() implementation

### DIFF
--- a/UIPClient.cpp
+++ b/UIPClient.cpp
@@ -320,7 +320,7 @@ UIPClient::read(uint8_t *buf, size_t size)
             {
               remain -= read;
               _eatBlock(&data->packets_in[0]);
-              if (uip_stopped(&uip_conns[data->state & UIP_CLIENT_SOCKETS]) && !(data->state & (UIP_CLIENT_CLOSE | UIP_CLIENT_REMOTECLOSED)))
+              if (uip_stopped(&uip_conns[data->conn_index]) && !(data->state & (UIP_CLIENT_CLOSE | UIP_CLIENT_REMOTECLOSED)))
                 data->state |= UIP_CLIENT_RESTART;
               if (data->packets_in[0] == NOBLOCK)
                 {
@@ -555,7 +555,8 @@ UIPClient::_allocateData()
       uip_userdata_t* data = &UIPClient::all_data[sock];
       if (!data->state)
         {
-          data->state = (uip_conn - uip_conns) | UIP_CLIENT_CONNECTED; // part of state is used for uip_conns index
+          data->conn_index = uip_conn - uip_conns;
+          data->state = UIP_CLIENT_CONNECTED;
           memset(&data->packets_in[0],0,sizeof(uip_userdata_t)-sizeof(data->state));
           return data;
         }

--- a/UIPClient.h
+++ b/UIPClient.h
@@ -46,12 +46,11 @@ extern "C" {
 #define UIP_SOCKET_NUMPACKETS 5
 #endif
 
-#define UIP_CLIENT_CONNECTED 0x10
-#define UIP_CLIENT_CLOSE 0x20
-#define UIP_CLIENT_REMOTECLOSED 0x40
-#define UIP_CLIENT_RESTART 0x80
-#define UIP_CLIENT_STATEFLAGS (UIP_CLIENT_CONNECTED | UIP_CLIENT_CLOSE | UIP_CLIENT_REMOTECLOSED | UIP_CLIENT_RESTART)
-#define UIP_CLIENT_SOCKETS ~UIP_CLIENT_STATEFLAGS
+#define UIP_CLIENT_CONNECTED 0x01
+#define UIP_CLIENT_CLOSE 0x02
+#define UIP_CLIENT_REMOTECLOSED 0x04
+#define UIP_CLIENT_RESTART 0x08
+#define UIP_CLIENT_ACCEPTED 0x10
 
 typedef uint8_t uip_socket_ptr;
 
@@ -62,6 +61,7 @@ typedef struct {
 } uip_userdata_closed_t;
 
 typedef struct {
+  uint8_t conn_index;
   uint8_t state;
   memhandle packets_in[UIP_SOCKET_NUMPACKETS];
   memhandle packets_out[UIP_SOCKET_NUMPACKETS];

--- a/UIPServer.cpp
+++ b/UIPServer.cpp
@@ -33,9 +33,24 @@ UIPClient UIPServer::available()
   for ( uip_userdata_t* data = &UIPClient::all_data[0]; data < &UIPClient::all_data[UIP_CONNS]; data++ )
     {
       if (data->packets_in[0] != NOBLOCK
-          && (((data->state & UIP_CLIENT_CONNECTED) && uip_conns[data->state & UIP_CLIENT_SOCKETS].lport ==_port)
+          && (((data->state & UIP_CLIENT_CONNECTED) && uip_conns[data->conn_index].lport ==_port)
               || ((data->state & UIP_CLIENT_REMOTECLOSED) && ((uip_userdata_closed_t *)data)->lport == _port)))
         return UIPClient(data);
+    }
+  return UIPClient();
+}
+
+UIPClient UIPServer::accept()
+{
+  UIPEthernetClass::tick();
+  for ( uip_userdata_t* data = &UIPClient::all_data[0]; data < &UIPClient::all_data[UIP_CONNS]; data++ )
+    {
+      if (!(data->state & UIP_CLIENT_ACCEPTED)
+          && (((data->state & UIP_CLIENT_CONNECTED) && uip_conns[data->conn_index].lport ==_port)
+              || ((data->state & UIP_CLIENT_REMOTECLOSED) && ((uip_userdata_closed_t *)data)->lport == _port))) {
+        data->state |= UIP_CLIENT_ACCEPTED;
+        return UIPClient(data);
+      }
     }
   return UIPClient();
 }
@@ -61,7 +76,7 @@ size_t UIPServer::write(const uint8_t *buf, size_t size)
   size_t ret = 0;
   for ( uip_userdata_t* data = &UIPClient::all_data[0]; data < &UIPClient::all_data[UIP_CONNS]; data++ )
     {
-      if ((data->state & UIP_CLIENT_CONNECTED) && uip_conns[data->state & UIP_CLIENT_SOCKETS].lport ==_port)
+      if ((data->state & UIP_CLIENT_CONNECTED) && uip_conns[data->conn_index].lport ==_port)
         ret += UIPClient::_write(data,buf,size);
     }
   return ret;

--- a/UIPServer.h
+++ b/UIPServer.h
@@ -47,6 +47,7 @@
 public:
   UIPServer(uint16_t);
   UIPClient available();
+  UIPClient accept();
   virtual void begin();
   virtual void begin(uint16_t port);
   virtual size_t write(uint8_t);


### PR DESCRIPTION
EthernetServer.accept() implementation. It required a new flag in uip_userdata_t.flags so conns index got a separate field in uip_userdata_t

based on https://www.arduino.cc/en/Reference/EthernetServerAccept

solves https://github.com/UIPEthernet/UIPEthernet/issues/84