### PR TITLE
Fix STM32F3 compilation errors on ARDUINO IDE

### DIFF
--- a/Dns.cpp
+++ b/Dns.cpp
@@ -9,7 +9,7 @@
 //#include <stdlib.h>
 #if defined(ARDUINO)
   #include "Arduino.h"
-  #if defined(__STM32F3__) || (!defined(ARDUINO_ARCH_STM32) && defined(STM32F3))
+  #if defined(__STM32F3__) || defined(STM32F3)
     #include "mbed/Udp.h"
   #else
     #include "Udp.h"

--- a/UIPClient.h
+++ b/UIPClient.h
@@ -22,16 +22,20 @@
 
 #include "ethernet_comp.h"
 #if defined(ARDUINO)
-  #include "Print.h"
-  #if defined(__STM32F3__) || (!defined(ARDUINO_ARCH_STM32) && defined(STM32F3)) || defined(__RFduino__)
+  #if defined(__STM32F3__) || defined(STM32F3) || defined(__RFduino__)
+    #include "mbed/Print.h"
     #include "mbed/Client.h"
+	#warning UIPClient ARDUINO mbed
   #else
+    #include "Print.h"
     #include "Client.h"
+	#warning UIPClient else
   #endif
 #endif
 #if defined(__MBED__)
   #include "mbed/Print.h"
   #include "mbed/Client.h"
+  #warning UIPClient mbed
 #endif
 #include "utility/mempool.h"
 #include "utility/logging.h"
@@ -71,11 +75,11 @@ typedef struct {
 #endif
 } uip_userdata_t;
 
-#if defined(ARDUINO) && (defined(ARDUINO_ARCH_STM32) || !defined(STM32F3)) && !defined(__RFduino__)
+#if defined(ARDUINO) && !defined(STM32F3) && !defined(__RFduino__)
   class UIPClient : public Client {
 #endif
-#if defined(__MBED__) || (!defined(ARDUINO_ARCH_STM32) && defined(STM32F3)) || defined(__RFduino__)
-  class UIPClient : public Print, public Client {
+#if defined(__MBED__) || defined(STM32F3) || defined(__RFduino__)
+  class UIPClient :  public Client {
 #endif
 public:
   UIPClient();

--- a/UIPEthernet.h
+++ b/UIPEthernet.h
@@ -26,7 +26,7 @@
 #endif
 #if defined(ARDUINO)
   #include <Arduino.h>
-  #if defined(__STM32F3__) || (!defined(ARDUINO_ARCH_STM32) && defined(STM32F3)) || defined(__RFduino__)
+  #if defined(__STM32F3__) || defined(STM32F3) || defined(__RFduino__)
     #include "mbed/IPAddress.h"
   #else
     #include "IPAddress.h"

--- a/UIPServer.h
+++ b/UIPServer.h
@@ -21,12 +21,13 @@
 
 #include "ethernet_comp.h"
 #if defined(ARDUINO)
-  #if defined(__RFduino__)
-    #include "Print.h"
+  #if defined(__STM32F3__) || defined(STM32F3) || defined(__RFduino__)
+    #include "mbed/Print.h"
   #else
+	  #warning UIPServer.h ARDUINO else
     #include "Print.h"
   #endif
-  #if defined(__STM32F3__) || (!defined(ARDUINO_ARCH_STM32) && defined(STM32F3)) || defined(__RFduino__)
+  #if defined(__STM32F3__) || defined(STM32F3) || defined(__RFduino__)
     #include "mbed/Server.h"
   #else
     #include "Server.h"
@@ -38,10 +39,10 @@
 #endif
 #include "UIPClient.h"
 
-#if defined(ARDUINO) && (defined(ARDUINO_ARCH_STM32) || !defined(STM32F3)) && !defined(__RFduino__)
+#if defined(ARDUINO) && !defined(STM32F3) && !defined(__RFduino__)
   class UIPServer : public Server {
 #endif
-#if defined(__MBED__) || (!defined(ARDUINO_ARCH_STM32) && defined(STM32F3)) || defined(__RFduino__)
+#if defined(__MBED__) || defined(STM32F3) || defined(__RFduino__)
   class UIPServer : public Print, public Server {
 #endif
 public:

--- a/UIPUdp.h
+++ b/UIPUdp.h
@@ -23,12 +23,13 @@
 #include "ethernet_comp.h"
 #if defined(ARDUINO)
   #include <Arduino.h>
-  #if defined(__RFduino__)
-    #include "Print.h"
+  #if defined(__STM32F3__) || defined(STM32F3) || defined(__RFduino__)
+    #include "mbed/Print.h"
   #else
+	  #warning PrintUIPUdp ARDUINO else
     #include "Print.h"
   #endif
-  #if defined(__STM32F3__) || (!defined(ARDUINO_ARCH_STM32) && defined(STM32F3)) || defined(__RFduino__)
+  #if defined(__STM32F3__) || defined(STM32F3) || defined(__RFduino__)
     #include "mbed/Udp.h"
   #else
     #include <Udp.h>
@@ -56,10 +57,10 @@ typedef struct {
   bool send;
 } uip_udp_userdata_t;
  
-#if defined(ARDUINO) && (defined(ARDUINO_ARCH_STM32) || !defined(STM32F3)) && !defined(__RFduino__)
+#if defined(ARDUINO) && !defined(STM32F3) && !defined(__RFduino__)
   class UIPUDP : public UDP {
 #endif
-#if defined(__MBED__) || (!defined(ARDUINO_ARCH_STM32) && defined(STM32F3)) || defined(__RFduino__)
+#if defined(__MBED__) || defined(STM32F3) || defined(__RFduino__)
   class UIPUDP : public Print, public UDP {
 #endif
 private:

--- a/mbed/Client.h
+++ b/mbed/Client.h
@@ -23,14 +23,27 @@
   #define client_h
   #if defined(__MBED__)
     #include "mbed/IPAddress.h"
+	#include "mbed/Print.h"
+	#include "Stream.h"
+	#warning Client mbed
   #endif
 
   #if defined(ARDUINO)
-    #include "IPAddress.h"
+	  #if defined(__STM32F3__) || defined(STM32F3) || defined(__RFduino__)
+		#include "mbed/IPAddress.h"
+		#include "mbed/Print.h"
+		#include "Stream.h"
+		#warning Client ARDUINO mbed
+	  #else
+		#include "IPAddress.h"
+		#include "Print.h"
+		#include "Stream.h"
+		#warning Client ARDUINO
+	  #endif
   #endif
 
-class   Client
-{
+class   Client : public Stream {
+
 public:
     virtual ~Client(){};
     virtual int         connect(IPAddress ip, uint16_t port) = 0;

--- a/mbed/IPAddress.cpp
+++ b/mbed/IPAddress.cpp
@@ -19,8 +19,13 @@
 #if !defined(ARDUINO_ARCH_AVR) && !defined(ARDUINO_ARCH_SAM)
 
 #if defined(ARDUINO)
-  #include <Arduino.h>
-  #include <IPAddress.h>
+  #if defined(__STM32F3__) || defined(STM32F3) || defined(__RFduino__)
+	  #include "mbed/Print.h"
+	  #include "mbed/IPAddress.h"
+	#else
+	  #include <Arduino.h>
+	  #include <IPAddress.h>
+#endif
 #endif
 #if defined(__MBED__)
   #include <mbed.h>

--- a/mbed/IPAddress.h
+++ b/mbed/IPAddress.h
@@ -28,8 +28,13 @@
 #endif
 
 #if defined(ARDUINO)
+  #if defined(__STM32F3__) || defined(STM32F3) || defined(__RFduino__)
+  #include "mbed/Printable.h"
+  #include "mbed/WString.h"
+	#else
   #include "Printable.h"
   #include "WString.h"
+#endif
 #endif
 
 // A class to make it easier to handle and pass around IP addresses

--- a/mbed/Print.cpp
+++ b/mbed/Print.cpp
@@ -27,9 +27,13 @@
 #include <math.h>
 #if defined(ARDUINO)
   #include "Arduino.h"
+  #if defined(__STM32F3__) || defined(STM32F3) || defined(__RFduino__)
+  #include "mbed/Print.h"
+	#else
   #include "Print.h"
+  #warning Print.cpp ARDUINO __FILE__
 #endif
-
+#endif
 #if defined(__MBED__)
   #include "mbed/Print.h"
 #endif

--- a/mbed/Print.h
+++ b/mbed/Print.h
@@ -20,6 +20,7 @@
 
 #ifndef Print_h
 #define Print_h
+#warning Print.h from mbed
 
 #if defined(__MBED__)
   #include <mbed.h>
@@ -38,8 +39,13 @@
   #include "mbed/Printable.h"
 #endif
 #if defined(ARDUINO)
+  #if defined(__STM32F3__) || defined(STM32F3) || defined(__RFduino__)
+  #include "mbed/WString.h"
+  #include "mbed/Printable.h"
+	#else
   #include "WString.h"
   #include "Printable.h"
+#endif
 #endif
 
 #define DEC 10

--- a/mbed/Udp.h
+++ b/mbed/Udp.h
@@ -36,12 +36,12 @@
 #ifndef udp_h
     #define udp_h
 
-    #if defined(__MBED__)
+    #if defined(__MBED__) 
       #include <mbed.h>
       #include "mbed/IPAddress.h"
     #else
-      #if defined(__RFduino__)
-        #include "IPAddress.h"
+	  #if defined(__STM32F3__) || defined(STM32F3) || defined(__RFduino__)
+        #include "mbed/IPAddress.h"
       #else
         #include "IPAddress.h"
       #endif

--- a/mbed/WString.cpp
+++ b/mbed/WString.cpp
@@ -27,7 +27,13 @@
 #endif
 
 #if defined(ARDUINO)
-  #include "WString.h"
+  #if defined(__STM32F3__) || defined(STM32F3) || defined(__RFduino__)
+	  #include "mbed/WString.h"
+	  #include "mbed/itoa.h"
+	  #include "mbed/dtostrf.h"
+	#else
+	  #include "WString.h"
+#endif
 #endif
 
 /*********************************************/

--- a/mbed/WString.h
+++ b/mbed/WString.h
@@ -33,7 +33,11 @@
 #endif
 
 #if defined(ARDUINO)
-  #include <avr/pgmspace.h>
+  #if defined(__STM32F3__) || defined(STM32F3) || defined(__RFduino__)
+    #include <mbed/pgmspace.h>
+  #else 
+	#include <avr/pgmspace.h>
+  #endif
 #endif
 
 // When compiling programs with this class, the following gcc parameters

--- a/mbed/millis.cpp
+++ b/mbed/millis.cpp
@@ -18,7 +18,8 @@
   */
 #if !defined(ARDUINO_ARCH_AVR) && !defined(ARDUINO_ARCH_SAM)
 
-#if defined(__MBED__)
+#if defined(__MBED__) 
+
 #include "millis.h"
 #include <mbed.h>
 

--- a/utility/Enc28J60Network.cpp
+++ b/utility/Enc28J60Network.cpp
@@ -39,7 +39,7 @@ uint8_t ENC28J60ControlCS = ENC28J60_CONTROL_CS;
    #if defined(ARDUINO)
      #if defined(STM32F2)
        #include <SPI.h>
-     #elif (defined(ARDUINO_ARCH_STM32) || !defined(STM32F3)) && !defined(__STM32F4__)
+     #elif !defined(STM32F3) && !defined(__STM32F4__) || defined(ARDUINO_ARCH_STM32)
        #include <SPI.h>
        extern SPIClass SPI;
      //#elif defined(ARDUINO_ARCH_AMEBA)
@@ -135,7 +135,7 @@ void Enc28J60Network::init(uint8_t* macaddr)
     LogObject.uart_send_strln(F("ENC28J60::init DEBUG:Use SPI lib SPI.begin()"));
   #endif
   #if defined(ARDUINO)
-    #if defined(__STM32F3__) || (!defined(ARDUINO_ARCH_STM32) && defined(STM32F3)) || defined(__STM32F4__)
+    #if !defined(ARDUINO_ARCH_STM32) && (defined(__STM32F3__) || defined(STM32F3) || defined(__STM32F4__))
       SPI.begin(SPI_9MHZ, MSBFIRST, 0);
     #else
       SPI.begin();

--- a/utility/Enc28J60Network.h
+++ b/utility/Enc28J60Network.h
@@ -205,7 +205,7 @@ extern uint8_t ENC28J60ControlCS;
 #endif
 
 #if defined(__MBED__) || defined(ARDUINO_ARCH_SAM) || defined(ARDUINO_ARCH_SAMD) || defined(__ARDUINO_ARC__) || defined(__STM32F1__) || defined(__STM32F3__) || defined(STM32F3) || defined(__STM32F4__) || defined(STM32F2) || defined(ESP8266) || defined(ARDUINO_ARCH_AMEBA) || defined(__MK20DX128__) || defined(__MKL26Z64__) || defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__) || defined(__IMXRT1062__) || defined(__RFduino__) || defined(ARDUINO_ARCH_STM32) || defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_MEGAAVR)
-   #if defined(ARDUINO) && (!defined(ARDUINO_ARCH_STM32) && defined(STM32F3))
+   #if defined(ARDUINO) && !defined(ARDUINO_ARCH_STM32) && defined(STM32F3)
       #include "HardwareSPI.h"
    #else
       #include <SPI.h>

--- a/utility/logging.h
+++ b/utility/logging.h
@@ -29,7 +29,8 @@
 
 #if ACTLOGLEVEL>LOG_NONE 
    #if defined(ARDUINO)
-     #if defined(__STM32F1__) || defined(__STM32F3__) || (!defined(ARDUINO_ARCH_STM32) && defined(STM32F3)) || defined(__STM32F4__) || defined(ARDUINO_ARCH_SAM)
+     #if defined(__STM32F1__) || defined(__STM32F3__) || defined(STM32F3) || defined(__STM32F4__) || defined(ARDUINO_ARCH_SAM)
+		#include "mbed/Print.h"
         #define LogObject Serial1
      #else
         #define LogObject Serial


### PR DESCRIPTION
Fix compilation errors with NUCLEO-32 STMF303.

- **Stream** Class not exist on **Client** Class
- **Print** Class conflict

Include [new STM32 core F3/F4 compatibility ](https://github.com/UIPEthernet/UIPEthernet/commit/c6d6519a260166b722b9cee5dd1f0fb2682e6782) fix