### PR TITLE
Enc28J60Network: reserve space for TSV. coded by N.Truchsess

### DIFF
--- a/UIPClient.cpp
+++ b/UIPClient.cpp
@@ -499,10 +499,10 @@ finish_newdata:
               if (send_len > 0)
                 {
                   UIPEthernetClass::uip_hdrlen = ((uint8_t*)uip_appdata)-uip_buf;
-                  UIPEthernetClass::uip_packet = Enc28J60Network::allocBlock(UIPEthernetClass::uip_hdrlen+send_len);
+                  UIPEthernetClass::uip_packet = Enc28J60Network::allocBlock(UIPEthernetClass::uip_hdrlen+send_len + UIP_SENDBUFFER_OFFSET + UIP_SENDBUFFER_PADDING);
                   if (UIPEthernetClass::uip_packet != NOBLOCK)
                     {
-                      Enc28J60Network::copyPacket(UIPEthernetClass::uip_packet,UIPEthernetClass::uip_hdrlen,u->packets_out[0],0,send_len);
+                      Enc28J60Network::copyPacket(UIPEthernetClass::uip_packet,UIPEthernetClass::uip_hdrlen + UIP_SENDBUFFER_OFFSET,u->packets_out[0],0,send_len);
                       UIPEthernetClass::packetstate |= UIPETHERNET_SENDPACKET;
                     }
                 }

--- a/UIPEthernet.cpp
+++ b/UIPEthernet.cpp
@@ -395,11 +395,11 @@ bool UIPEthernetClass::network_send()
       LogObject.uart_send_str(F(", hdrlen: "));
       LogObject.uart_send_decln(uip_hdrlen);
 #endif
-      Enc28J60Network::writePacket(uip_packet,0,uip_buf,uip_hdrlen);
+      Enc28J60Network::writePacket(uip_packet, UIP_SENDBUFFER_OFFSET,uip_buf,uip_hdrlen);
       packetstate &= ~ UIPETHERNET_SENDPACKET;
       goto sendandfree;
     }
-  uip_packet = Enc28J60Network::allocBlock(uip_len);
+  uip_packet = Enc28J60Network::allocBlock(uip_len + UIP_SENDBUFFER_OFFSET + UIP_SENDBUFFER_PADDING);
   if (uip_packet != NOBLOCK)
     {
 #if ACTLOGLEVEL>=LOG_DEBUG
@@ -408,7 +408,7 @@ bool UIPEthernetClass::network_send()
       LogObject.uart_send_str(F(", packet: "));
       LogObject.uart_send_decln(uip_packet);
 #endif
-      Enc28J60Network::writePacket(uip_packet,0,uip_buf,uip_len);
+      Enc28J60Network::writePacket(uip_packet, UIP_SENDBUFFER_OFFSET,uip_buf,uip_len);
       goto sendandfree;
     }
   return false;
@@ -573,7 +573,7 @@ uip_tcpchksum(void)
       sum = Enc28J60Network::chksum(
           sum,
           UIPEthernetClass::uip_packet,
-          UIP_IPH_LEN + UIP_LLH_LEN + upper_layer_memlen,
+          (UIPEthernetClass::packetstate & UIPETHERNET_SENDPACKET ? UIP_IPH_LEN + UIP_LLH_LEN + UIP_SENDBUFFER_OFFSET : UIP_IPH_LEN + UIP_LLH_LEN) + upper_layer_memlen,
           upper_layer_len - upper_layer_memlen
       );
 #if ACTLOGLEVEL>=LOG_DEBUG

--- a/utility/Enc28J60Network.cpp
+++ b/utility/Enc28J60Network.cpp
@@ -436,13 +436,10 @@ Enc28J60Network::sendPacket(memhandle handle)
     }
 
   memblock *packet = &blocks[handle];
-  uint16_t start = packet->begin-1;
-  uint16_t end = start + packet->size;
+  uint16_t start = packet->begin; // includes the UIP_SENDBUFFER_OFFSET for control byte
+  uint16_t end = start + packet->size - 1 - UIP_SENDBUFFER_PADDING; // end = start + size - 1 and padding for TSV is no included
 
-  // backup data at control-byte position
-  uint8_t data = readByte(start);
   // write control-byte (if not 0 anyway)
-  if (data)
     writeByte(start, 0);
 
   #if ACTLOGLEVEL>=LOG_DEBUG
@@ -494,10 +491,6 @@ Enc28J60Network::sendPacket(memhandle handle)
       LogObject.uart_send_strln(F("Enc28J60Network::sendPacket(memhandle handle) Errata 13 LATE COLLISION !!"));
     #endif
     }
-
-  //restore data on control-byte position
-  if (data)
-    writeByte(start, data);
 
   return success;
 }

--- a/utility/Enc28J60Network.h
+++ b/utility/Enc28J60Network.h
@@ -215,6 +215,9 @@ extern uint8_t ENC28J60ControlCS;
 
 #define UIP_RECEIVEBUFFERHANDLE 0xff
 
+#define UIP_SENDBUFFER_PADDING 7
+#define UIP_SENDBUFFER_OFFSET 1
+
 /*
  * Empfangen von ip-header, arp etc...
  * wenn tcp/udp -> tcp/udp-callback -> assign new packet to connection


### PR DESCRIPTION
from https://github.com/ntruchsess/arduino_uip/pull/103

this solves sometimes overwritten bytes of received packets, because the ENC writes Transmit Status Vector after a transmitted packet and the library didn't reserve a space for it.
also the control byte before the transmitted packet has now its own space.

