### PR TITLE
UdpServer example accepts only first packet (when no logging)

### DIFF
--- a/examples/UdpServer/UdpServer.ino
+++ b/examples/UdpServer/UdpServer.ino
@@ -125,9 +125,10 @@ while(true) {
 
     udp.stop();
     //restart with new connection to receive packets from other clients
+    success = udp.begin(5000);
     #if ACTLOGLEVEL>=LOG_INFO
       LogObject.uart_send_str(F("restart connection: "));
-      LogObject.uart_send_strln(udp.begin(5000) ? "success" : "failed");
+      LogObject.uart_send_strln(success ? "success" : "failed");
     #endif
   }
 }


### PR DESCRIPTION
Without logging, sample code accept only first udp packet.